### PR TITLE
fix symbols for orientation

### DIFF
--- a/cylindra/widgets/_reserved_layers.py
+++ b/cylindra/widgets/_reserved_layers.py
@@ -115,8 +115,12 @@ class ReservedLayers:
                 symbol_of_interest[:] = "o"
             case Ori.MinusToPlus:
                 symbol_of_interest[0], symbol_of_interest[-1] = "-", "+"
+                if len(symbol_of_interest) > 2:
+                    symbol_of_interest[1:-1] = "o"
             case Ori.PlusToMinus:
                 symbol_of_interest[0], symbol_of_interest[-1] = "+", "-"
+                if len(symbol_of_interest) > 2:
+                    symbol_of_interest[1:-1] = "o"
             case ori:  # pragma: no cover
                 raise RuntimeError(ori)
 


### PR DESCRIPTION
Point symbols were supposed to be like `+ooooo-` but they were `++++++-`.