### PR TITLE
Find image by relative path

### DIFF
--- a/cylindra/cli/run.py
+++ b/cylindra/cli/run.py
@@ -28,7 +28,7 @@ class ParserRun(ParserBase):
         self.add_argument("--output", "-o", type=str, default=None)
 
     def run_action(
-        self, path: str, headless: bool = False, output: str = None, **kwargs
+        self, path: str, headless: bool = False, output: str | None = None, **kwargs
     ):
         from runpy import run_path
 


### PR DESCRIPTION
Images are usually saved in a separate drive. In this case, reading a project will fail when one is using another PC or the drive character changed.
This PR will add `image_relative` field to the project.json as the alternative search path for the image.
