### PR TITLE
Update bounding_box design and fix related bugs 

### DIFF
--- a/cylindra/widgets/_reserved_layers.py
+++ b/cylindra/widgets/_reserved_layers.py
@@ -58,6 +58,8 @@ class ReservedLayers:
             contrast_limits=_calc_contrast_limits(img),
             blending="translucent_no_depth",
         )
+        self.image.bounding_box.points = False
+        self.image.bounding_box.line_color = "#a0a0a0"
 
     def highlight_spline(self, i: int):
         """Highlight the current spline."""

--- a/tests/test_gui_0.py
+++ b/tests/test_gui_0.py
@@ -834,6 +834,11 @@ def test_simulator(ui: CylindraMainWidget):
         radius=6,
         offsets=(0.0, 0.18),
     )
+    assert ui.splines[0].props.get_glob("npf") == 2
+    ui.macro.undo()
+    assert ui.splines[0].props.get_glob("npf") == 14
+    ui.macro.redo()
+    assert ui.splines[0].props.get_glob("npf") == 2
     ui.simulator._get_components()
     ui.simulator.expand(layer, by=0.1, yrange=(11, 15), arange=(0, 14), allev=True)
     ui.simulator.twist(layer, by=0.3, yrange=(11, 15), arange=(0, 14), allev=True)
@@ -869,6 +874,8 @@ def test_simulator(ui: CylindraMainWidget):
 @pytest_group("simulate", maxfail=1)
 def test_simulate_tomogram(ui: CylindraMainWidget):
     ui.simulator.create_image_with_straight_line(25, (40, 42, 42), scale=0.5)
+    ui.macro.undo()
+    ui.macro.redo()
     ui.simulator.generate_molecules(
         spline=0,
         spacing=4.06,


### PR DESCRIPTION
- The bug of bounding box color reverting to the original state was fixed by napari 0.5.3. This PR updates the awaited bounding box design.
- `create_empty_image` did not show bounding box because the `bounding_box.visible = True` statement was in the worker thread. This also fix the potential problem of updating the canvas from `create_empty_image_with_straight_line`.
- Implment undo/redo to some of the simulator methods.