### PR TITLE
Add method for z-projection

### DIFF
--- a/cylindra/widgets/subwidgets/menus.py
+++ b/cylindra/widgets/subwidgets/menus.py
@@ -214,6 +214,7 @@ class ImageMenu(ChildWidget):
 
     filter_reference_image = abstractapi()
     deconvolve_reference_image = abstractapi()
+    z_project_reference_image = abstractapi()
     invert_image = abstractapi()
     add_multiscale = abstractapi()
     set_multiscale = abstractapi()

--- a/tests/test_gui_0.py
+++ b/tests/test_gui_0.py
@@ -362,6 +362,7 @@ def test_spline_control(ui: CylindraMainWidget, tmpdir):
     ui.deconvolve_reference_image()
     ui.filter_reference_image()
     ui.save_reference_image(tmpdir / "ref.mrc")
+    ui.z_project_reference_image(method="max")
     ui.register_path(coords=coords_13pf)
     ui.register_path(coords=coords_13pf[::-1])
 


### PR DESCRIPTION
This PR adds a new method to overlay Z-projection on the tomogram slice so that user knows the overall distribution of particles/structures while picking particles/splines.