### PR TITLE
Don't test windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Cancel Previous Runs
@@ -40,7 +40,7 @@ jobs:
           python -m venv .venv
           echo "$GITHUB_WORKSPACE/.venv/$BIN" >> $GITHUB_PATH
 
-      - uses: tlambert03/setup-qt-libs@v1.5
+      - uses: tlambert03/setup-qt-libs@v1.8
       - name: Install dependencies
         run: python -m pip install .[testing]
 
@@ -48,7 +48,7 @@ jobs:
         run: maturin develop --release
 
       - name: Test
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@v2.2
         with:
           run: python -m pytest --cov=cylindra --cov=cylindra_builtins --cov-report=xml
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cylindra_ext"
-version = "1.0.0-beta.8"
+version = "1.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cylindra/components/landscape.py
+++ b/cylindra/components/landscape.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
@@ -771,15 +770,6 @@ class Landscape:
 def _norm_distance(v: str | nm, arr) -> nm:
     if not isinstance(v, str):
         return v
-    if v.startswith(("*", "+", "-")):
-        warnings.warn(
-            f"Distance specification using relative values like {v!r} is deprecated. "
-            f"Please use the numpy array object `d` for the array of distance. For "
-            "example, `d.mean()` for the mean distance.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        v = f"d.mean(){v}"
     ns = {"__builtins__": {}, "d": arr, "np": np}
     out = eval(v, ns, {})
     out_float = float(out)

--- a/cylindra/widgets/sta.py
+++ b/cylindra/widgets/sta.py
@@ -1,5 +1,4 @@
 import re
-import warnings
 import weakref
 from contextlib import suppress
 from enum import Enum
@@ -1187,15 +1186,6 @@ class SubtomogramAveraging(ChildWidget):
         t0.toc()
         return self._align_all_on_return.with_args([mole], [layer])
 
-    @property
-    def align_all_annealing(self):  # pragma: no cover
-        warnings.warn(
-            "align_all_annealing is deprecated. Use align_all_rma instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.align_all_rma
-
     @set_design(text="Simulated annealing (RMA)", location=Alignment)
     @dask_worker.with_progress(descs=_pdesc.align_annealing_fmt)
     def align_all_rma(
@@ -1680,15 +1670,6 @@ class SubtomogramAveraging(ChildWidget):
         return self._align_on_landscape_on_return.with_args(
             mole, landscape_layer.name, spl
         )
-
-    @property
-    def run_annealing_on_landscape(self):  # pragma: no cover
-        warnings.warn(
-            "run_annealing_on_landscape is deprecated. Use run_rma_on_landscape instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.run_rma_on_landscape
 
     @set_design(text="Run annealing (RMA)", location=LandscapeMenu)
     @dask_worker.with_progress(desc="Running simulated annealing")

--- a/docs/case_studies/custom_config.md
+++ b/docs/case_studies/custom_config.md
@@ -71,7 +71,7 @@ You now have lattice parameters of a representative segment of your structure. B
 these values, you can determine the config parameters. Open the config editor widget
 by following these steps:
 
-1. Open the spline slicer widget.
+1. Open the spline slicer widget as in 2.
    - `thickness_inner` and `thickness_outer` ... Set to the same value as the values you
      set in the spline slicer.
    - `clockwise` ... Click "Measure CW/CCW" button. This method will measure whether the
@@ -80,7 +80,7 @@ by following these steps:
      visually appears to have the "PlusToMinus" polarity, set this parameter to
      "PlusToMinus". Do the same for other cases.
 
-2. Open the spectra inspector widget.
+2. Open the spectra inspector widget as in 3.
    - `npf_range`, `spacing_range` and `twist_range` ... Set to a range that covers the
      measured parameters in the spectra inspector. There is no standard way to determine
      the range, as the actual achievable range depends on both the heterogeneity of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.8.3,<2.0.0"]
+requires = ["maturin==1.9.4"]
 build-backend = "maturin"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "platformdirs>=4.3.6",
 ]
 authors = [
-    { email = "liuha@med.kobe-u.ac.jp" },
+    { email = "liuhanjin.sc@gmail.com" },
     { name = "Hanjin Liu" }
 ]
 
@@ -62,7 +62,7 @@ testing = [
     "starfile>=0.5.11",
     "imodmodel>=0.1.0",
     "cookiecutter",
-    "maturin>=1.8.3,<2.0.0",
+    "maturin==1.9.4",
 ]
 all = [
     "pyqt6",

--- a/tests/test_gui_0.py
+++ b/tests/test_gui_0.py
@@ -1632,7 +1632,7 @@ def test_landscape_and_interaction(ui: CylindraMainWidget, tmpdir):
     ui.sta.run_align_on_landscape(layer_land)
     ui.sta.run_viterbi_on_landscape(
         layer_land,
-        range_long=("-0.1", "+0.1"),
+        range_long=("d.mean()-0.1", "d.mean() + 0.1"),
         angle_max=10,
     )
     # click preview
@@ -1641,8 +1641,8 @@ def test_landscape_and_interaction(ui: CylindraMainWidget, tmpdir):
     tester.click_preview()
     ui.sta.run_rma_on_landscape(
         layer_land.name,
-        range_long=("-0.1", "+0.1"),
-        range_lat=("-0.1", "+0.1"),
+        range_long=("d.mean() -0.1", "d.mean()+ 0.1"),
+        range_lat=("d.mean()- 0.1", "d.mean()  + 0.1"),
         angle_max=20,
         random_seeds=[0, 1],
     )
@@ -1700,7 +1700,7 @@ def test_landscape_and_interaction(ui: CylindraMainWidget, tmpdir):
     assert isinstance(layer_land, LandscapeSurface)
     ui.sta.run_rfa_on_landscape(
         layer_land,
-        range_long=("-0.1", "+0.1"),
+        range_long=("d.mean()-0.1", "d.mean()+0.1"),
         angle_max=5,
     )
 


### PR DESCRIPTION
Testing windows in github workflow fails with "no OpenGL context" recently, due to the update in napari 0.6.3.
Just skip this test for now.