### PR TITLE
Fix widget setup for the copy-feature method

### DIFF
--- a/cylindra/widgets/_ui_init.py
+++ b/cylindra/widgets/_ui_init.py
@@ -452,6 +452,11 @@ def _setup_fn_with_column_selection(self: CylindraMainWidget, gui: FunctionGui):
     gui[0].changed.connect(gui[1].reset_choices)
 
 
+@setup_function_gui(CylindraMainWidget.copy_molecules_features)
+def _setup_copy_molecules_features(self: CylindraMainWidget, gui: FunctionGui):
+    gui.source.changed.connect(gui.column.reset_choices)
+
+
 @setup_function_gui(CylindraMainWidget.binarize_feature)
 def _setup_binarize_feature(self: CylindraMainWidget, gui: FunctionGui):
     gui.layer.changed.connect(gui.target.reset_choices)

--- a/cylindra/widgets/main.py
+++ b/cylindra/widgets/main.py
@@ -1049,7 +1049,7 @@ class CylindraMainWidget(MagicTemplate):
                     self.Overview.contrast_limits = -chigh, -clow
                 return undo_callback(self.invert_image)
 
-        t0.toc()
+            t0.toc()
         return _invert_image_on_return
 
     @set_design(text=capitalize, location=_sw.ImageMenu.LabelsMenu)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pandas>=2.2.0",
     "polars>=1.35.1",
     "scikit-image>=0.21.0",
-    "napari>=0.6.5",
+    "napari>=0.7.0",
     "qtpy>=2.3.1",
     "qt-command-palette>=0.0.7",
     "matplotlib>=3.8.1",
@@ -62,6 +62,7 @@ testing = [
     "imodmodel>=0.1.0",
     "cookiecutter",
     "maturin>=1.9.6,<2.0.0",
+    "dask<2025",
 ]
 all = [
     "pyqt6",
@@ -70,6 +71,10 @@ all = [
     "starfile",
     "imodmodel",
     "cookiecutter",
+]
+recommended = [
+    "cylindra[all]",
+    "dask<2025",
 ]
 docs = [
     "pyqt6",
@@ -81,7 +86,7 @@ docs = [
     "mkdocs-material-extensions>=1.3.1",
     "mkdocstrings>=0.29.1,<1.0.0",
     "mkdocstrings-python>=1.16.12",
-    "maturin>=1.5.0,<2.0.0",
+    "maturin>=1.12.6,<2.0.0",
     "click<8.3.0",
 ]
 


### PR DESCRIPTION
Method `copy_molecules_features` was not correctly set up regarding to the `reset_choices` calls when the `source` parameter changed. This PR fixes this.