### PR TITLE
add `sample_every` parameter to `infer_polarity`

### DIFF
--- a/cylindra/components/tomogram/_cyl_tomo.py
+++ b/cylindra/components/tomogram/_cyl_tomo.py
@@ -961,6 +961,7 @@ class CylTomogram(Tomogram):
         binsize: int = 1,
         depth: nm = 40,
         mask_freq: bool = True,
+        sample_every: nm = 9999,
         update: bool = True,
     ) -> Ori:
         """Infer spline polarities using polar 2D image.
@@ -971,6 +972,12 @@ class CylTomogram(Tomogram):
             Spline ID that you want to analyze.
         binsize : int, default 1
             Multiscale bin size used for calculation.
+        mask_freq : bool, default True
+            If True, mask the frequency outside the lattice peaks during polarity
+            inference.
+        sample_every : float (nm), default 9999
+            Sample every this length along the spline to get polar images. Sample points
+            will be equally spaced along the spline from the center.
         depth : nm, default 40.0
             Depth of images used to infer polarities.
 
@@ -995,12 +1002,19 @@ class CylTomogram(Tomogram):
         ori_clockwise = Ori(cfg.clockwise)
         ori_counterclockwise = Ori.invert(ori_clockwise, allow_none=False)
         r_range = spl.radius_range()
-        point = 0.5  # the sampling point
-        coords = spl.local_cylindrical(r_range, depth, point, scale=current_scale)
-        polar = get_polar_image(imgb, coords, spl.radius, order=1)
+
+        num_points = ceilint(spl.length() / sample_every)
+        points = np.arange(1, num_points + 1) / (num_points + 1)
+
+        polar_imgs: list[ip.ImgArray] = []
+        for point in points:
+            coords = spl.local_cylindrical(r_range, depth, point, scale=current_scale)
+            polar = get_polar_image(imgb, coords, spl.radius, order=1)
+            polar_imgs.append(polar)
+        LOGGER.info(f" >> Using {num_points} segments ({depth:.1f} nm).")
         clkwise = is_clockwise(
             cfg,
-            polar,
+            sum(polar_imgs) / len(polar_imgs),
             mask_freq=mask_freq,
             npf=spl.props.get_glob(H.npf, None),
             logger=LOGGER,

--- a/cylindra/project/_defaults.py
+++ b/cylindra/project/_defaults.py
@@ -78,7 +78,7 @@ class TomogramDefaults(BaseModel):
 
 def _resolve_autofill(path: Path) -> Path | None:
     pattern = str(path)
-    if "*" in pattern or "?" in pattern:
+    if "*" in pattern or "?" in pattern or "[" in pattern:
         if matched_path := next(reversed(glob.glob(pattern)), None):
             return Path(matched_path)
-    return None
+    return Path(pattern)

--- a/cylindra/widgets/main.py
+++ b/cylindra/widgets/main.py
@@ -1333,6 +1333,7 @@ class CylindraMainWidget(MagicTemplate):
         splines: SplinesType = None,
         depth: Annotated[nm, {"min": 5.0, "max": 500.0, "step": 5.0}] = 40,
         bin_size: BinSizeType = 1,
+        sample_every: Annotated[nm, {"label": "Sample every (nm)", "min": 10.0, "max": 9999, "step": 1.0}] = 9999,
     ):  # fmt: skip
         """Automatically detect the cylinder polarities.
 
@@ -1345,11 +1346,18 @@ class CylindraMainWidget(MagicTemplate):
         Parameters
         ----------
         {splines}{depth}{bin_size}
+        sample_every : float, default 9999
+            Sample the spline every this length (nm) for polarity inference. If the
+            spline is not fitted well, or the tilt series alignment is not good,
+            decreasing this value may help to get more accurate result.
         """
         tomo = self.tomogram
         _old_orientations = [spl.orientation for spl in self.tomogram.splines]
         for i in self._norm_splines(splines):
-            tomo.infer_polarity(i=i, binsize=bin_size, depth=depth, update=True)
+            tomo.infer_polarity(
+                i=i, binsize=bin_size, depth=depth, sample_every=sample_every,
+                update=True
+            )  # fmt: skip
             yield
         _new_orientations = [spl.orientation for spl in self.tomogram.splines]
 

--- a/cylindra/widgets/subwidgets/runner.py
+++ b/cylindra/widgets/subwidgets/runner.py
@@ -70,6 +70,11 @@ class Runner(ChildWidget):
         Check if calculate global properties.
     infer_polarity : bool
         Check if infer spline polarity after run.
+    infer_every : nm
+        Sample every this length along the spline to get polar images for polarity
+        inference.
+    map_monomers : bool
+        Map monomers on the cylinder surface using the measured lattice parameters.
     """
 
     def _get_splines(self, _=None) -> list[tuple[str, int]]:
@@ -99,6 +104,9 @@ class Runner(ChildWidget):
     params2 = runner_params2
     global_props = vfield(True, label="Calculate global properties")
     infer_polarity = vfield(True, label="Infer polarity")
+    infer_every = vfield(9999.0, label="Infer polarity every (nm)").with_options(
+        min=1.0, max=9999.0, step=1.0
+    )
     map_monomers = vfield(False, label="Map monomers")
 
     @fit.connect
@@ -108,6 +116,10 @@ class Runner(ChildWidget):
     @local_props.connect
     def _toggle_localprops_params(self, val: bool):
         self.params2.enabled = val
+
+    @infer_polarity.connect
+    def _toggle_infer_polarity_params(self, val: bool):
+        self["infer_every"].enabled = val
 
     def _get_max_shift(self, w=None):
         if self.fit:
@@ -147,6 +159,7 @@ class Runner(ChildWidget):
         depth: Annotated[nm, {"bind": params2.depth}] = 50.0,
         global_props: Annotated[bool, {"bind": global_props}] = True,
         infer_polarity: Annotated[bool, {"bind": infer_polarity}] = True,
+        infer_every: Annotated[nm, {"bind": infer_every}] = 9999.0,
         map_monomers: Annotated[bool, {"bind": map_monomers}] = False,
     ):  # fmt: skip
         """Run workflow."""
@@ -182,7 +195,11 @@ class Runner(ChildWidget):
             )
             yield
         if infer_polarity:
-            yield from main.infer_polarity.arun(splines=splines, bin_size=bin_size)
+            yield from main.infer_polarity.arun(
+                splines=splines,
+                bin_size=bin_size,
+                sample_every=infer_every,
+            )
             yield
         if global_props:
             yield from main.global_cft_analysis.arun(splines=splines, bin_size=bin_size)


### PR DESCRIPTION
This PR allows user to set how many segment used for polarity inferrence. Decreasing this value makes this algorithm more robust for in situ samples.