### PR TITLE
Fix FilamentousGraph energy_diff_by_shift for tip-node shifts

### DIFF
--- a/src/annealing/graphs/filamentous.rs
+++ b/src/annealing/graphs/filamentous.rs
@@ -373,21 +373,30 @@ impl GraphTrait<Node1D<Shift>, EdgeType> for FilamentousGraph {
             e_old += e_old_diff;
             e_new += e_new_diff;
         }
-        if 0 < idx && idx < graph.node_count() - 1 {
+        let n = graph.node_count();
+        // Shifting `idx` can affect up to three deforming triplets: the one centered
+        // at `idx` itself (if it is not a tip node), and the ones centered at its
+        // prev/next neighbors (in which `idx` plays the role of the *other*
+        // endpoint). Note that `idx` need not have both a prev and a next for the
+        // latter two to apply -- e.g. if `idx` is a tip node, shifting it still
+        // changes the triplet centered at its one neighbor.
+        if 0 < idx && idx < n - 1 {
             let state_prev = graph.node_state(idx - 1);
             let state_next = graph.node_state(idx + 1);
             e_old += self.deforming(&state_prev, &state_old, &state_next);
             e_new += self.deforming(&state_prev, &state_new, &state_next);
-            if 1 < idx {
-                let state_prevprev = graph.node_state(idx - 2);
-                e_old += self.deforming(&state_prevprev, &state_prev, &state_old);
-                e_new += self.deforming(&state_prevprev, &state_prev, &state_new);
-            }
-            if idx < graph.node_count() - 2 {
-                let state_nextnext = graph.node_state(idx + 2);
-                e_old += self.deforming(&state_old, &state_next, &state_nextnext);
-                e_new += self.deforming(&state_new, &state_next, &state_nextnext);
-            }
+        }
+        if idx >= 2 {
+            let state_prevprev = graph.node_state(idx - 2);
+            let state_prev = graph.node_state(idx - 1);
+            e_old += self.deforming(&state_prevprev, &state_prev, &state_old);
+            e_new += self.deforming(&state_prevprev, &state_prev, &state_new);
+        }
+        if idx + 2 < n {
+            let state_next = graph.node_state(idx + 1);
+            let state_nextnext = graph.node_state(idx + 2);
+            e_old += self.deforming(&state_old, &state_next, &state_nextnext);
+            e_new += self.deforming(&state_new, &state_next, &state_nextnext);
         }
         e_new - e_old
     }

--- a/tests/test_annealing.py
+++ b/tests/test_annealing.py
@@ -1,0 +1,96 @@
+import numpy as np
+import pytest
+
+from cylindra._cylindra_ext import FilamentousAnnealingModel
+
+
+def _build_model(
+    seed: int,
+    num: int = 6,
+    local_shape: tuple[int, int, int] = (3, 5, 5),
+    spacing: float = 4.0,
+) -> FilamentousAnnealingModel:
+    rng = np.random.default_rng(seed)
+    nz, ny, nx = local_shape
+    center = np.array([nz // 2, ny // 2, nx // 2], dtype=np.float32)
+
+    # Nodes laid out along the world x-axis, `spacing` nm apart, so that each
+    # node's "center" shift maps back onto the straight line.
+    positions = np.zeros((num, 3), dtype=np.float32)  # columns: z, y, x
+    positions[:, 2] = np.arange(num) * spacing
+    origin = (positions - center).astype(np.float32)
+    zvec = np.tile([1.0, 0.0, 0.0], (num, 1)).astype(np.float32)
+    yvec = np.tile([0.0, 1.0, 0.0], (num, 1)).astype(np.float32)
+    xvec = np.tile([0.0, 0.0, 1.0], (num, 1)).astype(np.float32)
+
+    # Random internal energy landscape so that some nodes -- including the two
+    # tip nodes -- are pulled off the straight line, creating tension with the
+    # bending (deforming) energy of the triplet centered at their neighbor.
+    energy = rng.uniform(0.0, 2.0, size=(num, nz, ny, nx)).astype(np.float32)
+
+    model = (
+        FilamentousAnnealingModel(seed=seed)
+        .construct_graph(num)
+        .set_graph_coordinates(origin=origin, zvec=zvec, yvec=yvec, xvec=xvec)
+        .set_energy_landscape(energy)
+        .set_reservoir(temperature=1.0, time_constant=1.0, min_temperature=0.0)
+        .set_box_potential(2.0, 6.0, ang_max=0.3, cooling_rate=0.005)
+    )
+    model.init_shift_random()
+    return model
+
+
+def _lattice_neighbors(state: list[int], shape: tuple[int, int, int]) -> list[list[int]]:
+    """Single-step face-adjacent moves, mirroring `list_neighbors` (Rust)."""
+    neighbors = []
+    for axis in range(3):
+        s = state[axis]
+        upper = shape[axis] - 1
+        if 0 < s < upper:
+            deltas = (-1, 1)
+        elif s == 0:
+            deltas = (1,)
+        else:
+            deltas = (-1,)
+        for d in deltas:
+            nbr = list(state)
+            nbr[axis] += d
+            neighbors.append(nbr)
+    return neighbors
+
+
+def _best_improving_shift(model: FilamentousAnnealingModel) -> float:
+    """Brute-force search for a single-node, single-step shift that reduces
+    `model.energy()` below its current value. Returns the most negative energy
+    difference found (0.0 if no node has any improving shift)."""
+    shape = model.local_shape()
+    base_shifts = model.shifts()
+    base_energy = model.energy()
+    best_diff = 0.0
+    for idx in range(model.node_count()):
+        for nbr in _lattice_neighbors(list(base_shifts[idx]), shape):
+            trial = base_shifts.copy()
+            trial[idx] = nbr
+            model.set_shifts(trial)
+            diff = model.energy() - base_energy
+            if diff < best_diff:
+                best_diff = diff
+    model.set_shifts(base_shifts)
+    return best_diff
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_filamentous_cool_completely_reaches_local_optimum(seed: int):
+    # `energy_diff_by_shift` used to skip updating the bending (deforming)
+    # energy when shifting a tip node (idx == 0 or idx == node_count() - 1),
+    # even though shifting a tip node still changes the deforming-energy
+    # triplet centered at its one neighbor. That made `cool_completely` (and
+    # `simulate`, which relies on the same incremental energy calculation)
+    # stop at a state that is not actually a local optimum: a single-step
+    # shift of a tip node could still reduce the true energy.
+    model = _build_model(seed)
+    model.simulate(nsteps=4000)
+    model.cool_completely()
+
+    best_diff = _best_improving_shift(model)
+    assert best_diff == pytest.approx(0.0, abs=1e-4)


### PR DESCRIPTION
## Summary
- `FilamentousGraph::energy_diff_by_shift` only updated the deforming (bending) energy when the shifted node had both a prev and next neighbor (`0 < idx < node_count() - 1`). Shifting a tip node (`idx == 0` or `idx == node_count() - 1`) still changes the deforming triplet centered at its one neighbor, so the old code under-reported the true energy change for tip shifts.
- Since this incremental diff drives both `simulate()` and `cool_completely()` (via `try_all_shifts`), `FilamentousAnnealingModel` / RFA alignment could converge to a state that isn't actually a local energy optimum.
- Restructured the three deforming-triplet checks (centered at `idx`, at `idx`'s prev neighbor, at `idx`'s next neighbor) to be independent, mirroring the same fix already applied to `MicrotubuleGraph::energy_diff_by_shift`, adapted to `FilamentousGraph`'s flat `idx-1`/`idx-2`/`idx+1`/`idx+2` node addressing (vs. edge lookups).

## Test plan
- [x] Added `tests/test_annealing.py`: builds a small chain, runs `simulate()` + `cool_completely()`, then brute-force checks that no single-node shift can further reduce `model.energy()`.
- [x] Verified the test fails on the pre-fix code (6/10 seeds found real improving moves, up to ~1.35 energy) and passes cleanly (10/10 seeds) on the fixed code.
- [x] `cargo check` / `cargo test --lib` pass.
- [x] `pytest tests/test_annealing.py -v` passes (10 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
