### PR TITLE
Speed up RMA annealing by ~1.5x with no change in results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,10 @@ numpy = "0.29.0"
 rand = "0.8.3"
 mt19937 = "2.0.1"
 num = { version = "0.4.3", features = ["std"] }
+
+[profile.release]
+# The annealing hot loop spans several modules (potential/vector/coordinates), so
+# cross-module inlining matters a lot here. Note that `panic = "abort"` must NOT be
+# used because Rust panics have to unwind back into Python.
+lto = "fat"
+codegen-units = 1

--- a/src/annealing/graphs/basic.rs
+++ b/src/annealing/graphs/basic.rs
@@ -4,7 +4,7 @@ use numpy::{
 };
 use pyo3::PyResult;
 use super::traits::{
-    shape_for_indices, CylindricGraphTrait, GraphComponents, GraphTrait, Node2D
+    shape_for_indices, CylindricGraphTrait, GraphComponents, GraphTrait, Node2D, ShiftResult
 };
 
 use crate::{
@@ -17,7 +17,9 @@ use crate::{
             TrapezoidalPotential2D,
             LennardJonesLikePotential2D,
             BindingPotential2D,
+            EdgeScalars,
             EdgeType,
+            edge_scalars,
     },
         random::RandomNumberGenerator,
     }
@@ -26,9 +28,26 @@ use crate::{
 type Shift = Vector3D<isize>;
 
 #[derive(Clone)]
+/// Geometry of an edge that never changes once the coordinates are set.
+/// `ey` is the vector connecting the origins of the two local coordinate systems, and
+/// is required for the angle constraint. Because the angle energy only depends on
+/// `cos(dr, ey).abs()`, the sign of `ey` does not matter.
+pub struct EdgeGeometry {
+    pub ey: Vector3D<f32>,
+    pub ey_len: f32,
+}
+
+#[derive(Clone)]
 pub struct CylindricalGraph<T: BindingPotential2D> {
     components: GraphComponents<Node2D<Shift>, EdgeType>,
     coords: Arc<HashMap2D<CoordinateSystem<f32>>>,
+    edge_geometry: Arc<Vec<EdgeGeometry>>,
+    // Cached quantities of the *current* state of the graph. Because the binding
+    // potential is cooled at every iteration, the energies themselves cannot be cached,
+    // but these state-dependent scalars can, which makes re-evaluating the current
+    // energy of a node free of any coordinate arithmetic.
+    edge_scalars: Vec<EdgeScalars>,
+    internal_energies: Vec<f32>,
     energy: Arc<HashMap2D<Array<f32, Ix3>>>,
     pub binding_potential: T,
     pub local_shape: Shift,
@@ -109,7 +128,76 @@ impl<T> CylindricalGraph<T> where T: BindingPotential2D {
             );
         }
         self.coords = Arc::new(_coords);
+        self.update_edge_geometry();
         Ok(self)
+    }
+
+    /// Cache the coordinate-dependent, state-independent part of each edge.
+    fn update_edge_geometry(&mut self) {
+        let n_edges = self.components.edge_count();
+        let mut geometry = Vec::with_capacity(n_edges);
+        for i in 0..n_edges {
+            let (i0, i1) = self.components.edge_end(i);
+            let idx0 = &self.components.node_state(i0).index;
+            let idx1 = &self.components.node_state(i1).index;
+            let ey = self.coords[(idx1.y, idx1.a)].origin - self.coords[(idx0.y, idx0.a)].origin;
+            geometry.push(EdgeGeometry { ey, ey_len: ey.length() });
+        }
+        self.edge_geometry = Arc::new(geometry);
+        self.refresh_state_cache();
+    }
+
+    /// Calculate the scalars that describe the current geometry of the edge `edge_id`.
+    fn calc_edge_scalars(&self, edge_id: usize) -> EdgeScalars {
+        let (i0, i1) = self.components.edge_end(edge_id);
+        let node0 = self.components.node_state(i0);
+        let node1 = self.components.node_state(i1);
+        let coord0 = &self.coords[(node0.index.y, node0.index.a)];
+        let coord1 = &self.coords[(node1.index.y, node1.index.a)];
+        let dr = coord0.at_vec_fast(node0.state.into()) - coord1.at_vec_fast(node1.state.into());
+        let geom = &self.edge_geometry[edge_id];
+        edge_scalars(
+            &dr, dr.length(), &geom.ey, geom.ey_len, self.components.edge_state(edge_id),
+        )
+    }
+
+    /// Binding energy of the edge `edge_id` when one of its ends takes `node_state` and
+    /// the other one takes `other_state`.
+    fn binding_at(
+        &self,
+        node_state: &Node2D<Shift>,
+        other_state: &Node2D<Shift>,
+        edge_id: usize,
+    ) -> f32 {
+        let coord_self = &self.coords[(node_state.index.y, node_state.index.a)];
+        let coord_other = &self.coords[(other_state.index.y, other_state.index.a)];
+        let dr = coord_self.at_vec_fast(node_state.state.into())
+            - coord_other.at_vec_fast(other_state.state.into());
+        // `ey` only depends on the origins of the local coordinate systems, so that it
+        // is cached for each edge.
+        let geom = &self.edge_geometry[edge_id];
+        self.binding_potential.calculate_with_lengths(
+            &dr, dr.length(), &geom.ey, geom.ey_len, self.components.edge_state(edge_id),
+        )
+    }
+
+    /// Recalculate all the caches that depend on the current node states.
+    /// This method must be called whenever the node states, the coordinates or the
+    /// energy landscape are updated by anything other than `apply_shift`.
+    fn refresh_state_cache(&mut self) {
+        let n_nodes = self.components.node_count();
+        let n_edges = self.components.edge_count();
+        // The caches require the energy landscape, because the local coordinate caches
+        // used by `at_vec_fast` are only built in `set_energy_landscape`.
+        if self.energy.len() != n_nodes || n_nodes == 0 {
+            self.internal_energies = vec![0.0; n_nodes];
+            self.edge_scalars = vec![EdgeScalars::default(); n_edges];
+            return;
+        }
+        self.internal_energies = (0..n_nodes)
+            .map(|i| self.internal(self.components.node_state(i)))
+            .collect();
+        self.edge_scalars = (0..n_edges).map(|i| self.calc_edge_scalars(i)).collect();
     }
 
     /// Cool down the binding potential.
@@ -280,6 +368,7 @@ impl<T> CylindricalGraph<T> where T: BindingPotential2D {
             };
             self.components_mut().set_node_state(i, node);
         }
+        self.refresh_state_cache();
         Ok(self)
     }
 
@@ -295,6 +384,7 @@ impl<T> CylindricalGraph<T> where T: BindingPotential2D {
             };
             self.components_mut().set_node_state(i, node);
         }
+        self.refresh_state_cache();
         Ok(self)
     }
 
@@ -306,6 +396,9 @@ impl CylindricalGraph<TrapezoidalPotential2D> {
         Self {
             components: GraphComponents::empty(),
             coords: Arc::new(HashMap2D::new()),
+            edge_geometry: Arc::new(Vec::new()),
+            edge_scalars: Vec::new(),
+            internal_energies: Vec::new(),
             energy: Arc::new(HashMap2D::new()),
             binding_potential: TrapezoidalPotential2D::unbounded(),
             local_shape: Vector3D::new(0, 0, 0),
@@ -320,6 +413,9 @@ impl CylindricalGraph<LennardJonesLikePotential2D> {
         Self {
             components: GraphComponents::empty(),
             coords: Arc::new(HashMap2D::new()),
+            edge_geometry: Arc::new(Vec::new()),
+            edge_scalars: Vec::new(),
+            internal_energies: Vec::new(),
             energy: Arc::new(HashMap2D::new()),
             binding_potential: LennardJonesLikePotential2D::unbounded(),
             local_shape: Vector3D::new(0, 0, 0),
@@ -367,30 +463,6 @@ impl<T> GraphTrait<Node2D<Shift>, EdgeType> for CylindricalGraph<T> where T: Bin
         self.binding_potential.calculate(&dr, &ey, typ)
     }
 
-    fn binding_old_new(
-        &self,
-        state_old: &Node2D<Shift>,
-        state_new: &Node2D<Shift>,
-        other_state: &Node2D<Shift>,
-        typ: &EdgeType,
-    ) -> (f32, f32) {
-        let vec_old = state_old.state;
-        let vec_new = state_new.state;
-        let vec_other = other_state.state;
-        let coord_old = &self.coords[(state_old.index.y, state_old.index.a)];
-        let coord_new = &self.coords[(state_new.index.y, state_new.index.a)];
-        let coord_other = &self.coords[(other_state.index.y, other_state.index.a)];
-        let point_other = coord_other.at_vec_fast(vec_other.into());
-        let dr_old = coord_old.at_vec_fast(vec_old.into()) - point_other;
-        let dr_new = coord_new.at_vec_fast(vec_new.into()) - point_other;
-        // ey_* is required for the angle constraint.
-        let ey_old = coord_other.origin - coord_old.origin;
-        let ey_new = coord_other.origin - coord_new.origin;
-        let e_old = self.binding_potential.calculate(&dr_old, &ey_old, typ);
-        let e_new = self.binding_potential.calculate(&dr_new, &ey_new, typ);
-        (e_old, e_new)
-    }
-
     /// Return a random neighbor state of a given node state.
     fn random_local_neighbor_state(
         &self,
@@ -404,25 +476,42 @@ impl<T> GraphTrait<Node2D<Shift>, EdgeType> for CylindricalGraph<T> where T: Bin
     }
 
     /// Energy difference by shifting a state of node at idx.
+    /// `state_old` must be the current state of the node at `idx`, which is guaranteed
+    /// by every caller. Its energy is therefore taken from the caches instead of being
+    /// calculated again from the coordinates.
     fn energy_diff_by_shift(
         &self,
         idx: usize,
         state_old: &Node2D<Shift>,
         state_new: &Node2D<Shift>,
     ) -> f32 {
+        debug_assert_eq!(self.internal_energies[idx], self.internal(&state_old));
         let graph = self.components();
-        let mut e_old = self.internal(&state_old);
+        let mut e_old = self.internal_energies[idx];
         let mut e_new = self.internal(&state_new);
         for edge_id in graph.connected_edge_indices(idx) {
             let edge_id = *edge_id;
             let ends = graph.edge_end(edge_id);
             let other_idx = if ends.0 == idx { ends.1 } else { ends.0 };
             let other_state = graph.node_state(other_idx);
-            let (e_old_diff, e_new_diff) = self.binding_old_new(&state_old, &state_new, &other_state, graph.edge_state(edge_id));
-            e_old += e_old_diff;
-            e_new += e_new_diff;
+            let typ = graph.edge_state(edge_id);
+            e_old += self.binding_potential.energy_of(&self.edge_scalars[edge_id], typ);
+            e_new += self.binding_at(&state_new, &other_state, edge_id);
         }
         e_new - e_old
+    }
+
+    /// Update the node state and all the caches that depend on it.
+    fn apply_shift(&mut self, result: ShiftResult<Node2D<Shift>>) {
+        let idx = result.index;
+        self.components.set_node_state(idx, result.state);
+        let eng = self.internal(self.components.node_state(idx));
+        self.internal_energies[idx] = eng;
+        for k in 0..self.components.connected_edge_count(idx) {
+            let edge_id = self.components.connected_edge_id(idx, k);
+            let scalars = self.calc_edge_scalars(edge_id);
+            self.edge_scalars[edge_id] = scalars;
+        }
     }
 
     /// Initialize the node states to the center of each local coordinates.
@@ -433,6 +522,7 @@ impl<T> GraphTrait<Node2D<Shift>, EdgeType> for CylindricalGraph<T> where T: Bin
             let idx = node.index.clone();
             self.components.set_node_state(i, Node2D { index: idx, state: center.clone() });
         }
+        self.refresh_state_cache();
         self
     }
 
@@ -473,6 +563,7 @@ impl<T> GraphTrait<Node2D<Shift>, EdgeType> for CylindricalGraph<T> where T: Bin
             self.components.set_node_state(i, Node2D { index: idx.clone(), state: center.clone() })
         }
         self.energy = Arc::new(_energy);
+        self.refresh_state_cache();
         Ok(self)
     }
 }

--- a/src/annealing/graphs/filamentous.rs
+++ b/src/annealing/graphs/filamentous.rs
@@ -338,7 +338,7 @@ impl GraphTrait<Node1D<Shift>, EdgeType> for FilamentousGraph {
         state_old: &Node1D<Shift>,
         state_new: &Node1D<Shift>,
         other_state: &Node1D<Shift>,
-        _: &EdgeType,
+        _: usize,
     ) -> (f32, f32) {
         let vec_old = state_old.state;
         let vec_new = state_new.state;
@@ -369,7 +369,7 @@ impl GraphTrait<Node1D<Shift>, EdgeType> for FilamentousGraph {
             let ends = graph.edge_end(edge_id);
             let other_idx = if ends.0 == idx { ends.1 } else { ends.0 };
             let other_state = graph.node_state(other_idx);
-            let (e_old_diff, e_new_diff) = self.binding_old_new(&state_old, &state_new, &other_state, graph.edge_state(edge_id));
+            let (e_old_diff, e_new_diff) = self.binding_old_new(&state_old, &state_new, &other_state, edge_id);
             e_old += e_old_diff;
             e_new += e_new_diff;
         }

--- a/src/annealing/graphs/traits.rs
+++ b/src/annealing/graphs/traits.rs
@@ -96,6 +96,16 @@ impl<Sn, Se> GraphComponents<Sn, Se> {
         self.edges[i].iter()
     }
 
+    /// Number of edges connected to node i.
+    pub fn connected_edge_count(&self, i: usize) -> usize {
+        self.edges[i].len()
+    }
+
+    /// The k-th edge ID connected to node i.
+    pub fn connected_edge_id(&self, i: usize, k: usize) -> usize {
+        self.edges[i][k]
+    }
+
     pub fn edge_end(&self, i: usize) -> (usize, usize) {
         self.edge_ends[i]
     }
@@ -129,15 +139,16 @@ pub trait GraphTrait<N: Clone, E: Clone> {
     /// Set the energy landscape array to the graph.
     fn set_energy_landscape(&mut self, energy: ArcArray<f32, Ix4>) -> PyResult<&Self>;
 
-    /// Return the old and new binding energies.
+    /// Return the old and new binding energies of the edge `edge_id`.
     /// Override this if a more efficient implementation is available.
     fn binding_old_new(
         &self,
         state_old: &N,
         state_new: &N,
         other_state: &N,
-        typ: &E,
+        edge_id: usize,
     ) -> (f32, f32) {
+        let typ = self.components().edge_state(edge_id);
         (
             self.binding(state_old, other_state, typ),
             self.binding(state_new, other_state, typ),

--- a/src/annealing/potential.rs
+++ b/src/annealing/potential.rs
@@ -7,21 +7,70 @@ pub trait BindingPotential {
     }
 
 }
-pub trait BindingPotential2D : BindingPotential {
-    fn longitudinal(&self, dr: &Vector3D<f32>, vec: &Vector3D<f32>) -> f32;
-    fn lateral(&self, dr: &Vector3D<f32>, vec: &Vector3D<f32>) -> f32;
+#[derive(Clone, Copy, Default)]
+/// The scalars that fully determine the binding energy of an edge.
+/// Because these values do not depend on the potential parameters (which change every
+/// iteration by cooling), they can be cached for the current state of the graph and be
+/// reused as long as none of the two nodes moves.
+pub struct EdgeScalars {
+    /// Distance between the two molecule centers.
+    pub dist: f32,
+    /// |cos| of the angle between `dr` and the vector connecting the two local
+    /// coordinate origins. Not used (and not calculated) for lateral edges.
+    pub cos_abs: f32,
+}
 
-    /// Calculate the binding energy of the given conditions.
-    /// # Arguments
-    /// * `dr` - The vector in the world coordinate between the two molecule centers.
-    /// * `vec` - The vector in the world coordinate between the origin of the local coordinate
-    ///   systems.
-    /// * `typ` - The type of the edge.
+/// Calculate the scalars that describe the geometry of an edge.
+/// # Arguments
+/// * `dr` - The vector in the world coordinate between the two molecule centers.
+/// * `dr_len` - The length of `dr`.
+/// * `vec` - The vector in the world coordinate between the origin of the local coordinate
+///   systems. Only used for longitudinal edges.
+/// * `vec_len` - The length of `vec`.
+/// * `typ` - The type of the edge.
+pub fn edge_scalars(
+    dr: &Vector3D<f32>,
+    dr_len: f32,
+    vec: &Vector3D<f32>,
+    vec_len: f32,
+    typ: &EdgeType,
+) -> EdgeScalars {
+    match typ {
+        EdgeType::Longitudinal => EdgeScalars {
+            dist: dr_len,
+            cos_abs: dr.cos_angle_with_lengths(vec, dr_len, vec_len).abs(),
+        },
+        EdgeType::Lateral => EdgeScalars { dist: dr_len, cos_abs: 0.0 },
+    }
+}
+
+pub trait BindingPotential2D : BindingPotential {
+    /// Binding energy calculated from the cached scalars of an edge.
+    fn energy_of(&self, scalars: &EdgeScalars, typ: &EdgeType) -> f32;
+
+    /// Calculate the binding energy of the given conditions, with the vector lengths
+    /// already known. See `edge_scalars` for the arguments.
+    fn calculate_with_lengths(
+        &self,
+        dr: &Vector3D<f32>,
+        dr_len: f32,
+        vec: &Vector3D<f32>,
+        vec_len: f32,
+        typ: &EdgeType,
+    ) -> f32 {
+        self.energy_of(&edge_scalars(dr, dr_len, vec, vec_len, typ), typ)
+    }
+
+    /// Same as `calculate_with_lengths` but the vector lengths are calculated here.
+    /// This method is for the code paths that are not performance critical.
     fn calculate(&self, dr: &Vector3D<f32>, vec: &Vector3D<f32>, typ: &EdgeType) -> f32 {
-        match typ {
-            EdgeType::Longitudinal => self.longitudinal(dr, vec),
-            EdgeType::Lateral => self.lateral(dr, vec),
-        }
+        let dr_len = dr.length();
+        // `vec` is not used for lateral edges, so its length is not calculated.
+        let vec_len = match typ {
+            EdgeType::Longitudinal => vec.length(),
+            EdgeType::Lateral => 0.0,
+        };
+        self.calculate_with_lengths(dr, dr_len, vec, vec_len, typ)
     }
 }
 
@@ -63,9 +112,8 @@ impl TrapezoidalBoundary {
         }
     }
 
-    /// Calculated energy of given square of distance.
-    pub fn energy(&self, dr: &Vector3D<f32>) -> f32 {
-        let dist = dr.length();
+    /// Calculated energy of the given distance.
+    pub fn energy_at(&self, dist: f32) -> f32 {
         if dist < self.dist_min {
             self.slope * (self.dist_min - dist)
         } else if self.dist_max < dist {
@@ -73,6 +121,11 @@ impl TrapezoidalBoundary {
         } else {
             0.0
         }
+    }
+
+    /// Calculated energy of given distance vector.
+    pub fn energy(&self, dr: &Vector3D<f32>) -> f32 {
+        self.energy_at(dr.length())
     }
 }
 
@@ -83,6 +136,26 @@ impl TrapezoidalBoundary {
 struct TrapezoidalCosineBoundary {
     ang_max: f32,
     slope: f32,
+    /// |cos| above which the angle is surely within `ang_max`, so that `acos` does not
+    /// have to be called. See `cos_threshold`.
+    cos_thresh: f32,
+}
+
+/// Return the |cos| above which `acos(|cos|) <= ang_max` surely holds.
+///
+/// `acos` is monotonically decreasing, so the exact threshold is `cos(ang_max)`. The
+/// margin covers the rounding errors of `cos` and `acos` (a few ulps of the angle,
+/// which is orders of magnitude smaller than the margin); inputs that fall inside the
+/// margin take the `acos` path, so the result is bit-wise identical to always calling
+/// `acos`. `ang_max` greater than pi/2 can never be exceeded because `acos` of a
+/// non-negative value is at most pi/2.
+fn cos_threshold(ang_max: f32) -> f32 {
+    const MARGIN: f32 = 1e-6;
+    if ang_max > std::f32::consts::FRAC_PI_2 {
+        -1.0  // |cos| >= -1 always holds, i.e. the energy is always zero.
+    } else {
+        ang_max.cos() + MARGIN
+    }
 }
 
 impl TrapezoidalCosineBoundary {
@@ -91,25 +164,39 @@ impl TrapezoidalCosineBoundary {
             return value_error!("Maximum angle must be positive");
         }
         Ok(
-            Self { ang_max, slope }
+            Self { ang_max, slope, cos_thresh: cos_threshold(ang_max) }
         )
     }
 
     pub fn unbounded() -> Self {
-        Self { ang_max: f32::INFINITY, slope: 0.0, }
+        Self {
+            ang_max: f32::INFINITY,
+            slope: 0.0,
+            cos_thresh: cos_threshold(f32::INFINITY),
+        }
     }
 
     ///           o         Cosine is calculated as the angle between the
     ///    o     i+1        y axis and the vector from i to i+1. The y axis
     ///    i                of local coordinates is always parallel to the
     /// ---------------> y  y axis.
-    pub fn energy(&self, dr: &Vector3D<f32>, vec: &Vector3D<f32>) -> f32 {
-        let ang = dr.cos_angle(vec).abs().acos();
+    /// Energy calculated from |cos| of the angle between the two vectors.
+    /// Note that the energy does not depend on the sign of the cosine.
+    pub fn energy_of_cos(&self, cos_abs: f32) -> f32 {
+        if cos_abs >= self.cos_thresh {
+            // The angle is surely within the allowed range; `acos` is not needed.
+            return 0.0;
+        }
+        let ang = cos_abs.acos();
         if ang > self.ang_max {
             self.slope * (ang - self.ang_max)
         } else {
             0.0
         }
+    }
+
+    pub fn energy(&self, dr: &Vector3D<f32>, vec: &Vector3D<f32>) -> f32 {
+        self.energy_of_cos(dr.cos_angle(vec).abs())
     }
 }
 
@@ -190,15 +277,16 @@ impl BindingPotential for TrapezoidalPotential2D {
 }
 
 impl BindingPotential2D for TrapezoidalPotential2D {
-    fn longitudinal(&self, dr: &Vector3D<f32>, vec: &Vector3D<f32>) -> f32 {
-        // Energy coming from longitudinal distance
-        let eng_dist = self.lon.energy(dr);
-        let eng_ang = self.angle.energy(dr, vec);
-        eng_dist + eng_ang
-    }
-
-    fn lateral(&self, dr: &Vector3D<f32>, _vec: &Vector3D<f32>) -> f32 {
-        self.lat.energy(&dr)
+    fn energy_of(&self, scalars: &EdgeScalars, typ: &EdgeType) -> f32 {
+        match typ {
+            EdgeType::Longitudinal => {
+                // Energy coming from the longitudinal distance and the angle
+                let eng_dist = self.lon.energy_at(scalars.dist);
+                let eng_ang = self.angle.energy_of_cos(scalars.cos_abs);
+                eng_dist + eng_ang
+            }
+            EdgeType::Lateral => self.lat.energy_at(scalars.dist),
+        }
     }
 }
 
@@ -306,9 +394,8 @@ impl LennardJonesLikeBoundary {
         }
     }
 
-    /// Calculated energy of given square of distance.
-    pub fn energy(&self, dr: &Vector3D<f32>) -> f32 {
-        let dist = dr.length();
+    /// Calculated energy of the given distance.
+    pub fn energy_at(&self, dist: f32) -> f32 {
         if dist < self.dist_min {
             self.slope * (self.dist_min - dist)
         } else if self.dist_max < dist {
@@ -403,14 +490,15 @@ impl BindingPotential for LennardJonesLikePotential2D {
 }
 
 impl BindingPotential2D for LennardJonesLikePotential2D {
-    fn longitudinal(&self, dr: &Vector3D<f32>, vec: &Vector3D<f32>) -> f32 {
-        // Energy coming from longitudinal distance
-        let eng_dist = self.lon.energy(dr);
-        let eng_ang = self.angle.energy(dr, vec);
-        eng_dist + eng_ang
-    }
-
-    fn lateral(&self, dr: &Vector3D<f32>, _vec: &Vector3D<f32>) -> f32 {
-        self.lat.energy(&dr)
+    fn energy_of(&self, scalars: &EdgeScalars, typ: &EdgeType) -> f32 {
+        match typ {
+            EdgeType::Longitudinal => {
+                // Energy coming from the longitudinal distance and the angle
+                let eng_dist = self.lon.energy_at(scalars.dist);
+                let eng_ang = self.angle.energy_of_cos(scalars.cos_abs);
+                eng_dist + eng_ang
+            }
+            EdgeType::Lateral => self.lat.energy_at(scalars.dist),
+        }
     }
 }

--- a/src/coordinates/vector.rs
+++ b/src/coordinates/vector.rs
@@ -113,11 +113,10 @@ impl<T: Real> Vector3D<T> {
         self.z * self.z + self.y * self.y + self.x * self.x
     }
 
-    /// Cosine between two vectors.
-    pub fn cos_angle(&self, other: &Vector3D<T>) -> T {
+    /// Cosine between two vectors, with the lengths of the vectors already known.
+    /// `a` and `b` must be `self.length()` and `other.length()` respectively.
+    pub fn cos_angle_with_lengths(&self, other: &Vector3D<T>, a: T, b: T) -> T {
         let dot_prd = self.dot(other);
-        let a = self.length();
-        let b = other.length();
         let cos = dot_prd / (a * b);
         if cos > T::one() {
             T::one()
@@ -126,6 +125,11 @@ impl<T: Real> Vector3D<T> {
         } else {
             cos
         }
+    }
+
+    /// Cosine between two vectors.
+    pub fn cos_angle(&self, other: &Vector3D<T>) -> T {
+        self.cos_angle_with_lengths(other, self.length(), other.length())
     }
 
     /// Radian between two vectors.


### PR DESCRIPTION
## Summary

Makes the RMA / RFA simulated annealing inner loop about **1.5x faster** without changing any result. Every optimization here preserves the exact sequence of floating point operations, so the output is **bit-wise identical** to the current implementation — same shifts, same energy history, same iteration count, for the same seed.

The annealing loop runs on the order of `11.5 * nmole * prod(local_shape)` steps per trial (e.g. ~6.5M steps for 780 molecules on a 9³ search grid), so the per-step cost is essentially the whole runtime. This PR removes redundant work from that step.

## What changed

**Build profile** (`Cargo.toml`) — adds `[profile.release]` with `lto = "fat"` and `codegen-units = 1`. The hot loop spans several modules (`potential` / `coordinates` / `graphs`), so cross-module inlining matters. `panic = "abort"` is deliberately **not** used, because Rust panics have to unwind back into Python.

**Stop recomputing vector lengths**
- `binding_old_new` derived the `ey` vector (connecting the origins of the two local coordinate systems) twice per edge, and took its length twice more inside `cos_angle` — even though `ey` depends only on the coordinates, which are fixed after `set_graph_coordinates`. It is now precomputed per edge in `EdgeGeometry { ey, ey_len }`.
- The old and new states of a trial move always share the same node index, hence the same local coordinate system; the code looked it up twice.
- The longitudinal potential computed `dr.length()` once for the distance term and again inside `cos_angle` for the angle term. The potential functions now receive the lengths the caller already has.

**Skip `acos` when the angle is surely within the limit** — `acos(|cos|) <= ang_max` is equivalent to `|cos| >= cos(ang_max)`, so the angle energy can return zero without calling `acos`. The threshold carries a margin (`1e-6`) that is orders of magnitude larger than the rounding errors of `cos`/`acos`, so any input near the boundary still takes the `acos` path — the result is therefore unchanged. When `ang_max > pi/2` (e.g. the `angle_max=90` default of `run_annealing`) the term is provably always zero and is short-circuited entirely.

**Cache the scalars of the current state** — the binding potential is cooled at every iteration, so the binding *energies* cannot be cached, but the scalars they are computed from can:
- `EdgeScalars { dist, cos_abs }` per edge and the internal energy per node.
- The "old" side of a trial move is by definition the current state of the graph, so evaluating it no longer touches the coordinates at all. This halves the number of binding evaluations per step.
- The caches are updated incrementally in `apply_shift` (only the moved node and its incident edges) and rebuilt by `refresh_state_cache` whenever the states, coordinates or energy landscape are replaced. A `debug_assert` in the hot loop guards the invariant.
- The energy formula is now expressed once, as `energy_of(&EdgeScalars, typ)`, so the cached path and the direct path cannot drift apart.

## Verification

- **Bit-exactness**: the three builds (before / after) were loaded into a single Python process and run side by side. SHA-256 digests over the energy history, shifts, iteration count, longitudinal/lateral distances and angles, binding energies and edge info match exactly, across multiple seeds, 3 problem sizes and 2 kinds of energy landscape, for all four models: `CylindricAnnealingModel`, `CylindricAnnealingModelLJ`, `FilamentousAnnealingModel` and `DefectiveCylindricAnnealingModel`.
- **Cache invariant**: a debug build (with the `debug_assert` active) ran ~1.35M annealing steps without tripping it.
- `pytest tests/test_splines.py tests/test_utils.py` → 67 passed. (The GUI test suite could not run in this environment because of an unrelated, pre-existing `magicgui` version mismatch.)

## Benchmark

Interleaved A/B measurement — all builds loaded in one process, pinned to a P-core, minimum over several repetitions (the machine has a hybrid P/E-core CPU, which makes naive cross-process timing swing by up to 2x).

| Problem size | before | after |
|---|---|---|
| 390 molecules, 7³ grid, noisy landscape | 2.673 s | **x1.50** |
| 780 molecules, 9³ grid, noisy landscape | 11.840 s | **x1.48** |
| 390 molecules, 7³ grid, peaked landscape | 2.473 s | **x1.50** |
| 780 molecules, 9³ grid, peaked landscape | 10.988 s | **x1.49** |

("peaked" = the landscape minimum sits near the centre for every molecule, i.e. the lattice constraints are actually satisfiable, which is what a real cross-correlation landscape of a well-aligned lattice looks like.)

## Notes for the reviewer

- The signature of `GraphTrait::binding_old_new` changed from taking `typ: &E` to taking `edge_id: usize`, so that implementations can reach the per-edge caches. `FilamentousGraph` ignores it as before; `DefectiveCylindricGraph` does not use this method.
- The angle energy is invariant under the sign of `ey`, because it only uses `cos(...).abs()`. Negating an IEEE float and the products/sums derived from it is exact, so a single cached `ey` per edge is safe regardless of which end of the edge is moving. The same argument covers `dr`, whose sign depends on which endpoint is treated as "self".
- Only the `CylindricalGraph` caches state; the defective and filamentous graphs keep the previous behaviour and benefit only from the build profile, the shared potential refactor and the `acos` fast path.
- Profiling note for follow-ups: removing `acos` entirely accounts for only ~8% (measured by comparing against `angle_max=90`, where the fast path always fires), and LTO for ~3%. The remaining cost looks memory-bound — the per-node energy landscapes are separate heap allocations behind `HashMap2D<Option<Array3>>`, and the adjacency is a `Vec<Vec<usize>>`. Flattening those is the next lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
