### PR TITLE
(breaking) More accurate `map_monomers`

### DIFF
--- a/cylindra/components/spline/_cyl_spline.py
+++ b/cylindra/components/spline/_cyl_spline.py
@@ -172,23 +172,17 @@ class CylSpline(Spline):
         """
         length = self.length()
         cp = self.cylinder_params(**kwargs)
+        nrise = cp.start_raw
         ly = cp.spacing_proj
-        la = cp.lat_spacing_proj
-        factor = ly / la
+        la = (cp.perimeter + nrise * cp.radius * cp.twist_rad) / cp.npf
         ny = roundint(length / ly) + 1  # number of monomers in y-direction
-
-        if offsets is None:
-            offsets = (0.0, 0.0)
 
         return CylinderModel(
             shape=(ny, cp.npf),
-            tilts=(
-                cp.tan_skew * factor,
-                cp.tan_rise_raw / factor,
-            ),
-            intervals=(ly, la / cp.perimeter * 2 * np.pi),
+            tilts=(cp.tan_skew * ly / la, nrise / cp.npf),
+            intervals=(ly, la / cp.radius),
             radius=cp.radius,
-            offsets=offsets,
+            offsets=offsets or (0.0, 0.0),
         )
 
     def update_props(

--- a/cylindra/components/tomogram/_cyl_tomo.py
+++ b/cylindra/components/tomogram/_cyl_tomo.py
@@ -1236,9 +1236,13 @@ class CylTomogram(Tomogram):
             df_loc = spl.props.loc
             glob = df_loc.select(pl.selectors.numeric()).mean()
             if H.npf in df_loc.columns:
-                glob = glob.with_columns(df_loc[H.npf].mode().first())
+                glob = glob.with_columns(
+                    pl.lit(df_loc[H.npf].mode().first()).alias(H.npf)
+                )
             if H.start in df_loc.columns:
-                glob = glob.with_columns(df_loc[H.start].mode().first())
+                glob = glob.with_columns(
+                    pl.lit(df_loc[H.start].mode().first()).alias(H.start)
+                )
             for c, val in glob.to_dict().items():
                 kwargs[c] = val[0]
         return spl.cylinder_model(offsets=offsets, **kwargs)

--- a/cylindra/widgets/_annealing.py
+++ b/cylindra/widgets/_annealing.py
@@ -121,6 +121,13 @@ def preview_landscape_function(
     )
 
 
+def _determine_bins(data: np.ndarray):
+    _min, _max = data.min(), data.max()
+    if _max - _min < 1e-3:
+        return 1
+    return min(48, data.size // 2)
+
+
 def _preview_function(
     widget: SubtomogramAveraging,
     fgui: FunctionGui,
@@ -143,7 +150,9 @@ def _preview_function(
     max_lon = _eval_dist_like(range_long[1], data_lon)
     min_lat = _eval_dist_like(range_lat[0], data_lat)
     max_lat = _eval_dist_like(range_lat[1], data_lat)
-    lon_hist = canvas[0].add_hist(data_lon, bins=24, density=False, name="Longitudinal")
+    lon_hist = canvas[0].add_hist(
+        data_lon, bins=_determine_bins(data_lon), density=False, name="Longitudinal"
+    )
     color_ok = "yellow"
     color_ng = "red"
     if min_lon is None:
@@ -158,7 +167,9 @@ def _preview_function(
     lon_high = canvas[0].add_infline((max_lon, 0), 90, color=color_ok, ls=":")
     canvas[0].add_infline((0, 0), 0, color="gray")
     canvas[0].title = "Longitudinal distances"
-    lat_hist = canvas[1].add_hist(data_lat, bins=24, density=False, name="Lateral")
+    lat_hist = canvas[1].add_hist(
+        data_lat, bins=_determine_bins(data_lat), density=False, name="Lateral"
+    )
     lat_low = canvas[1].add_infline((min_lat, 0), 90, color=color_ok, ls=":")
     lat_high = canvas[1].add_infline((max_lat, 0), 90, color=color_ok, ls=":")
     canvas[1].add_infline((0, 0), 0, color="gray")

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -137,8 +137,9 @@ def test_mapping(orientation):
     tomo.global_cft_params(nsamples=2)
     mole = tomo.map_monomers(i=None, orientation=orientation)[0]
     dist_lon, dist_lat = get_distances(mole, tomo.splines[0], scale_factor=1)
-    assert dist_lon.max() - dist_lon.min() < 1e-3
-    assert dist_lat.max() - dist_lat.min() < 1e-3
+    # should be uniquely distributed
+    assert np.quantile(dist_lon, 0.95) - np.quantile(dist_lon, 0.05) < 0.015
+    assert np.quantile(dist_lat, 0.95) - np.quantile(dist_lat, 0.05) < 0.015
     tomo.map_centers(orientation=orientation)
     tomo.map_pf_line(orientation=orientation)
 

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -126,6 +126,8 @@ def test_chunked_straightening():
 
 @pytest.mark.parametrize("orientation", [None, "PlusToMinus", "MinusToPlus"])
 def test_mapping(orientation):
+    from cylindra.widgets._annealing import get_distances
+
     path = TEST_DIR / "13pf_MT.tif"
     tomo = CylTomogram.imread(path)
     tomo.add_spline(coords=[[18.97, 190.0, 28.99], [18.97, 107.8, 51.48]])
@@ -133,7 +135,10 @@ def test_mapping(orientation):
     tomo.splines[0].radius = 9
     tomo.splines[0].orientation = "PlusToMinus"
     tomo.global_cft_params(nsamples=2)
-    tomo.map_monomers(orientation=orientation)
+    mole = tomo.map_monomers(i=None, orientation=orientation)[0]
+    dist_lon, dist_lat = get_distances(mole, tomo.splines[0], scale_factor=1)
+    assert dist_lon.max() - dist_lon.min() < 1e-3
+    assert dist_lat.max() - dist_lat.min() < 1e-3
     tomo.map_centers(orientation=orientation)
     tomo.map_pf_line(orientation=orientation)
 


### PR DESCRIPTION
In the old implementation, the lateral distance of located particles is slightly off at the seam position when twist is nonzero. This PR fixes the math of cylinder model construction to solve this bug.